### PR TITLE
fix/add-necessary-folders

### DIFF
--- a/src/hooks/.gitkeep
+++ b/src/hooks/.gitkeep
@@ -1,0 +1,2 @@
+# Este arquivo mantém a pasta no Git
+# Pasta para hooks customizados do React

--- a/src/routes/.gitkeep
+++ b/src/routes/.gitkeep
@@ -1,0 +1,2 @@
+# Este arquivo mantém a pasta no Git
+# Pasta para configuração de rotas

--- a/src/services/.gitkeep
+++ b/src/services/.gitkeep
@@ -1,0 +1,2 @@
+# Este arquivo mantém a pasta no Git
+# Pasta para serviços de API e integrações

--- a/src/store/.gitkeep
+++ b/src/store/.gitkeep
@@ -1,0 +1,2 @@
+# Este arquivo mantém a pasta no Git
+# Pasta para gerenciamento de estado (Redux, Zustand, etc.)

--- a/src/styles/.gitkeep
+++ b/src/styles/.gitkeep
@@ -1,0 +1,2 @@
+# Este arquivo mantém a pasta no Git
+# Pasta para estilos globais e temas

--- a/src/tests/.gitkeep
+++ b/src/tests/.gitkeep
@@ -1,0 +1,2 @@
+# Este arquivo mantém a pasta no Git
+# Pasta para testes unitários e de integração


### PR DESCRIPTION
Adição de pastas necessárias para o projeto que o Git não mapeia